### PR TITLE
Bump rubyzip to support 3.x and widen addressable range

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
       fail-fast: false
     steps:
       - name: Checkout

--- a/lib/ro_crate/writer.rb
+++ b/lib/ro_crate/writer.rb
@@ -44,7 +44,7 @@ module ROCrate
     # @param destination [String, ::File] The destination where to write the RO-Crate zip.
     # @param skip_preview [Boolean] Whether or not to skip generation of the RO-Crate preview HTML file.
     def write_zip(destination, skip_preview: false)
-      Zip::File.open(destination, Zip::File::CREATE) do |zip|
+      Zip::File.open(destination, create: true) do |zip|
         @crate.payload.each do |path, entry|
           next if entry.directory?
           next if skip_preview && entry&.source.is_a?(ROCrate::PreviewGenerator)

--- a/ro_crate.gemspec
+++ b/ro_crate.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/ResearchObject/ro-crate-ruby'
   s.require_paths = ['lib']
   s.licenses    = ['MIT']
-  s.add_runtime_dependency 'addressable', '>= 2.7', '< 2.9'
-  s.add_runtime_dependency 'rubyzip', '~> 2.0.0'
+  s.add_runtime_dependency 'addressable', '>= 2.7', '< 3'
+  s.add_runtime_dependency 'rubyzip', '>= 2.3', '< 4'
   s.add_development_dependency 'rake', '~> 13.0.0'
   s.add_development_dependency 'test-unit', '~> 3.5.3'
   s.add_development_dependency 'simplecov', '~> 0.21.2'


### PR DESCRIPTION
## Summary

This PR adds support for rubyzip 3.x and updates dependency constraints accordingly.

 - Relax `rubyzip` runtime dep from `~> 2.0.0` to `>= 2.3, < 4`.
 - Relax `addressable` runtime dep from `>= 2.7, < 2.9` to `>= 2.7, < 3`.
 - Verify gem test suite green.

## Motivation

This PR enables compatibility with Rubyzip 3.x, which is required in newer Ruby/Rails environments. Current dependency constraints prevent upgrading without relaxing version bounds in downstream applications (e.g. when used alongside roo >= 2.4 and addressable 2.9.x).

Issue #30 tracks Rubyzip 3.0 support; this PR addresses that requirement.

## Verification

- Full test suite executed, verified on:
  - Ruby 2.7.8 with rubyzip 2.4.1, addressable 2.9.0
  - Ruby 3.4.4 with rubyzip 3.3.0, addressable 2.9.0
- Manual ZIP round-trip test validated

## Ruby compatibility

Rubyzip 3.x requires Ruby >= 2.7, therefore Ruby 2.6 is removed from the CI matrix.

